### PR TITLE
Update doi-service-server to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,13 +33,24 @@ lazy val headerLicenseValue = Some(
 )
 lazy val headerMappingsValue = HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment
 
-lazy val akkaCirceVersion = "0.3.0"
-lazy val akkaHttpVersion = "10.1.11"
-lazy val akkaVersion = "2.6.5"
+lazy val akkaHttpVersion = SettingKey[String]("akkaHttpVersion")
+lazy val akkaVersion = SettingKey[String]("akkaVersion")
+lazy val akkaCirceVersion = SettingKey[String]("akkaCirceVersion")
+
+lazy val akkaCirce212Version = "0.3.0"
+lazy val akkaCirce213Version = "0.4.0"
+
+
+lazy val akkaHttp212Version = "10.1.11"
+lazy val akkaHttp213Version = "10.2.7"
+
+lazy val akka212Version = "2.6.5"
+lazy val akka213Version = "2.6.8"
+
 lazy val circeVersion = SettingKey[String]("circeVersion")
 lazy val circe212Version = "0.11.1"
 lazy val circe213Version = "0.14.1"
-lazy val authMiddlewareVersion = "4.2.3"
+lazy val authMiddlewareVersion = "5.1.3"
 lazy val serviceUtilitiesVersion = "8-9751ee3"
 lazy val utilitiesVersion = "4-55953e4"
 lazy val slickVersion = "3.3.0"
@@ -50,7 +61,7 @@ lazy val enumeratumVersion = SettingKey[String]("enumeratumVersion")
 lazy val enumeratum212Version = "1.5.13"
 lazy val enumeratum213Version = "1.7.0"
 lazy val monocleVersion = "2.0.0"
-lazy val discoverServiceClientVersion = "20-83899a7"
+lazy val discoverServiceClientVersion = "35-afcdaef"
 
 lazy val common = project
   .enablePlugins(AutomateHeaderPlugin)
@@ -70,14 +81,24 @@ lazy val common = project
       enumeratum212Version,
       enumeratum213Version
     ),
+    akkaHttpVersion := getVersion(
+      scalaVersion.value,
+      akkaHttp212Version,
+      akkaHttp213Version
+    ),
+    akkaVersion := getVersion(
+      scalaVersion.value,
+      akka212Version,
+      akka213Version
+    ),
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion.value,
       "io.circe" %% "circe-generic" % circeVersion.value,
       "io.circe" %% "circe-jawn" % circeVersion.value,
       "com.beachape" %% "enumeratum" % enumeratumVersion.value,
       "com.beachape" %% "enumeratum-circe" % enumeratumVersion.value,
-      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-stream" % akkaVersion
+      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion.value,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion.value
     ),
     libraryDependencies ++= handle212OnlyDependency(
       scalaVersion.value,
@@ -113,14 +134,24 @@ lazy val scripts = project
       enumeratum212Version,
       enumeratum213Version
     ),
+    akkaHttpVersion := getVersion(
+      scalaVersion.value,
+      akkaHttp212Version,
+      akkaHttp213Version
+    ),
+    akkaVersion := getVersion(
+      scalaVersion.value,
+      akka212Version,
+      akka213Version
+    ),
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion.value,
       "io.circe" %% "circe-generic" % circeVersion.value,
       "io.circe" %% "circe-jawn" % circeVersion.value,
       "com.beachape" %% "enumeratum" % enumeratumVersion.value,
       "com.beachape" %% "enumeratum-circe" % enumeratumVersion.value,
-      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion.value,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion.value,
       "com.pennsieve" %% "discover-service-client" % discoverServiceClientVersion,
       "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion
     ),
@@ -152,6 +183,21 @@ lazy val server = project
     Integration / testOptions := Seq(
       Tests.Filter(_.toLowerCase.contains("integration"))
     ),
+    akkaHttpVersion := getVersion(
+      scalaVersion.value,
+      akkaHttp212Version,
+      akkaHttp213Version
+    ),
+    akkaVersion := getVersion(
+      scalaVersion.value,
+      akka212Version,
+      akka213Version
+    ),
+    akkaCirceVersion := getVersion(
+      scalaVersion.value,
+      akkaCirce212Version,
+      akkaCirce213Version
+    ),
     libraryDependencies ++= Seq(
       "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion,
       "com.pennsieve" %% "utilities" % utilitiesVersion,
@@ -163,7 +209,7 @@ lazy val server = project
       "com.github.tminglei" %% "slick-pg" % slickPgVersion,
       "com.github.tminglei" %% "slick-pg_circe-json" % slickPgVersion,
       "io.scalaland" %% "chimney" % "0.2.1",
-      "org.mdedetrich" %% "akka-http-circe" % akkaCirceVersion,
+      "org.mdedetrich" %% "akka-http-circe" % akkaCirceVersion.value,
       "org.postgresql" % "postgresql" % "42.2.4",
       "ch.qos.logback" % "logback-classic" % logbackVersion,
       "ch.qos.logback" % "logback-core" % logbackVersion,
@@ -176,8 +222,8 @@ lazy val server = project
       "com.whisk" %% "docker-testkit-scalatest" % dockerItVersion % Test,
       "com.whisk" %% "docker-testkit-impl-spotify" % dockerItVersion % Test,
       "com.pennsieve" %% "utilities" % utilitiesVersion % Test classifier "tests",
-      "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
-      "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
+      "com.typesafe.akka" %% "akka-testkit" % akkaVersion.value % Test,
+      "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion.value % Test,
       "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.714" % Test
     ),
     Compile / guardrailTasks :=

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import CrossCompilationUtil.{
   handle212OnlyDependency,
   scalaVersionMatch
 }
+import sbt.librarymanagement.{ Disabled, InclExclRule }
 
 ThisBuild / organization := "com.pennsieve"
 
@@ -11,7 +12,7 @@ lazy val scala212 = "2.12.11"
 lazy val scala213 = "2.13.8"
 lazy val supportedScalaVersions = List(scala212, scala213)
 
-ThisBuild / scalaVersion := scala212
+ThisBuild / scalaVersion := scala213
 
 ThisBuild / resolvers ++= Seq(
   "pennsieve-maven-proxy" at "https://nexus.pennsieve.cc/repository/maven-public"
@@ -38,8 +39,7 @@ lazy val akkaVersion = SettingKey[String]("akkaVersion")
 lazy val akkaCirceVersion = SettingKey[String]("akkaCirceVersion")
 
 lazy val akkaCirce212Version = "0.3.0"
-lazy val akkaCirce213Version = "0.4.0"
-
+lazy val akkaCirce213Version = "0.5.0"
 
 lazy val akkaHttp212Version = "10.1.11"
 lazy val akkaHttp213Version = "10.2.7"
@@ -53,9 +53,9 @@ lazy val circe213Version = "0.14.1"
 lazy val authMiddlewareVersion = "5.1.3"
 lazy val serviceUtilitiesVersion = "8-9751ee3"
 lazy val utilitiesVersion = "4-55953e4"
-lazy val slickVersion = "3.3.0"
-lazy val slickPgVersion = "0.17.3"
-lazy val dockerItVersion = "0.9.7"
+lazy val slickVersion = "3.3.3"
+lazy val slickPgVersion = "0.20.3"
+lazy val dockerItVersion = "0.9.9"
 lazy val logbackVersion = "1.2.3"
 lazy val enumeratumVersion = SettingKey[String]("enumeratumVersion")
 lazy val enumeratum212Version = "1.5.13"
@@ -202,23 +202,24 @@ lazy val server = project
       "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion,
       "com.pennsieve" %% "utilities" % utilitiesVersion,
       "com.pennsieve" %% "auth-middleware" % authMiddlewareVersion,
-      "com.github.pureconfig" %% "pureconfig" % "0.10.2",
-      "com.iheart" %% "ficus" % "1.4.0",
+      "com.github.pureconfig" %% "pureconfig" % "0.17.1",
+      "com.iheart" %% "ficus" % "1.5.2",
       "com.typesafe.slick" %% "slick" % slickVersion,
       "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
       "com.github.tminglei" %% "slick-pg" % slickPgVersion,
       "com.github.tminglei" %% "slick-pg_circe-json" % slickPgVersion,
-      "io.scalaland" %% "chimney" % "0.2.1",
+      "io.scalaland" %% "chimney" % "0.6.1",
       "org.mdedetrich" %% "akka-http-circe" % akkaCirceVersion.value,
+      "com.typesafe.akka" %% "akka-slf4j" % akkaVersion.value,
       "org.postgresql" % "postgresql" % "42.2.4",
       "ch.qos.logback" % "logback-classic" % logbackVersion,
       "ch.qos.logback" % "logback-core" % logbackVersion,
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
       "net.logstash.logback" % "logstash-logback-encoder" % "5.2",
       "com.github.julien-truffaut" %% "monocle-core" % monocleVersion,
       "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion,
       // Test dependencies
-      "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.12" % Test,
       "com.whisk" %% "docker-testkit-scalatest" % dockerItVersion % Test,
       "com.whisk" %% "docker-testkit-impl-spotify" % dockerItVersion % Test,
       "com.pennsieve" %% "utilities" % utilitiesVersion % Test classifier "tests",
@@ -226,12 +227,14 @@ lazy val server = project
       "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion.value % Test,
       "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.714" % Test
     ),
+    excludeDependencies ++= Seq(
+      ExclusionRule("com.typesafe.akka", "akka-slf4j")
+    ),
     Compile / guardrailTasks :=
       List(
         ScalaServer(
           file("swagger/doi-service.yml"),
-          pkg = "com.pennsieve.doi.server",
-          modules = List("akka-http", "circe-0.11")
+          pkg = "com.pennsieve.doi.server"
         )
       ),
     docker / dockerfile := {

--- a/scripts/UpdateAllPublishedDoi.scala
+++ b/scripts/UpdateAllPublishedDoi.scala
@@ -78,13 +78,13 @@ object UpdateAllPublishedDoi extends App {
   }
 
   private def toCollectionDto(
-    discoverCollection: PublicCollectionDTO
+    discoverCollection: PublicCollectionDto
   ): CollectionDto = {
     CollectionDto(discoverCollection.name, discoverCollection.id)
   }
 
   private def toExternalPublicationDto(
-    discoverExternalPub: PublicExternalPublicationDTO
+    discoverExternalPub: PublicExternalPublicationDto
   ): ExternalPublicationDto = {
     ExternalPublicationDto(
       discoverExternalPub.doi,
@@ -137,7 +137,7 @@ object UpdateAllPublishedDoi extends App {
 
     val datasetPage = Await.result(res.value, 3.minutes).right.get
 
-    datasetPage.datasets.map { dataset: PublicDatasetDTO =>
+    datasetPage.datasets.map { dataset: PublicDatasetDto =>
       {
         var a = 0
         for (a <- 1 to dataset.version) {
@@ -147,7 +147,7 @@ object UpdateAllPublishedDoi extends App {
               .getDatasetVersion(dataset.id, a)
               .leftSemiflatMap(handleGuardrailError())
               .flatMap {
-                _.fold[EitherT[Future, CoreError, PublicDatasetDTO]](
+                _.fold[EitherT[Future, CoreError, PublicDatasetDto]](
                   handleOK = response => EitherT.pure(response),
                   handleGone =
                     msg => EitherT.leftT(DiscoverIgnorableError("Unpublished")),

--- a/scripts/UpdateAllPublishedDoi.scala
+++ b/scripts/UpdateAllPublishedDoi.scala
@@ -135,7 +135,7 @@ object UpdateAllPublishedDoi extends App {
 
     } yield datasets
 
-    val datasetPage = Await.result(res.value, 3.minutes).right.get
+    val datasetPage = Await.result(res.value, 3.minutes).toOption.get
 
     datasetPage.datasets.map { dataset: PublicDatasetDto =>
       {

--- a/server/src/main/scala/com/pennsieve/doi/Ports.scala
+++ b/server/src/main/scala/com/pennsieve/doi/Ports.scala
@@ -37,6 +37,7 @@ class Ports(
     hikariDataSource.setPassword(config.postgres.password)
     hikariDataSource.setMaximumPoolSize(config.postgres.numConnections)
     hikariDataSource.setDriverClassName(config.postgres.driver)
+    hikariDataSource.setConnectionInitSql("set time zone 'UTC'")
 
     // Currently minThreads, maxThreads and maxConnections MUST be the same value
     // https://github.com/slick/slick/issues/1938

--- a/server/src/test/scala/com/pennsieve/doi/clients/CitationClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/doi/clients/CitationClientSpec.scala
@@ -5,9 +5,10 @@ package com.pennsieve.doi.clients
 import com.pennsieve.doi.models.Doi
 import com.pennsieve.doi.{ NoDoiException, ServiceSpecHarness, TestUtilities }
 import com.pennsieve.test.AwaitableImplicits
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CitationClientSpec extends WordSpec with Matchers {
+class CitationClientSpec extends AnyWordSpec with Matchers {
 
   "CitationClient" should {
 

--- a/server/src/test/scala/com/pennsieve/doi/db/CitationCacheMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/doi/db/CitationCacheMapperSpec.scala
@@ -5,10 +5,11 @@ package com.pennsieve.doi.db
 import com.pennsieve.doi.db.profile.api._
 import com.pennsieve.doi.ServiceSpecHarness
 import com.pennsieve.test.AwaitableImplicits
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class CitationCacheMapperSpec
-    extends WordSpec
+    extends AnyWordSpec
     with ServiceSpecHarness
     with AwaitableImplicits
     with Matchers {

--- a/server/src/test/scala/com/pennsieve/doi/db/DoiMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/doi/db/DoiMapperSpec.scala
@@ -5,10 +5,11 @@ package com.pennsieve.doi.db
 import com.pennsieve.doi.models.Doi
 import com.pennsieve.doi.{ NoDoiException, ServiceSpecHarness, TestUtilities }
 import com.pennsieve.test.AwaitableImplicits
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class DoiMapperSpec
-    extends WordSpec
+    extends AnyWordSpec
     with ServiceSpecHarness
     with AwaitableImplicits
     with Matchers {


### PR DESCRIPTION
We update the server to 2.13. The client is still cross compiled to 2.11 and 2.13.