### PR TITLE
Fix datacite json encoding decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .idea/
+.bsp/
 
 ## Redis ##
 *.rdb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,62 +13,89 @@ node("executor") {
         passwordVariable: "PENNSIEVE_NEXUS_PW"
     )
 
-    stage("Build") {
-        withCredentials([pennsieveNexusCreds]) {
-            sh "$sbt clean +compile"
-        }
-    }
-
-    stage("Test") {
-        withCredentials([pennsieveNexusCreds]) {
-            try {
-                sh "$sbt coverageOn +test"
-            } finally {
-                junit '**/target/test-reports/*.xml'
-            }
-        }
-    }
-
-    // stage("Integration Test") {
-    //     withCredentials([pennsieveNexusCreds]) {
-    //         try {
-    //             sh "$sbt coverageOn integration:test"
-    //         } finally {
-    //             junit '**/target/test-reports/*.xml'
-    //         }
-    //     }
-    // }
-
-    stage("Test Coverage") {
-        withCredentials([pennsieveNexusCreds]) {
-            sh "$sbt coverageReport"
-        }
-    }
-
-    if (env.BRANCH_NAME == 'main') {
-        stage("Publish Jars") {
+    try {
+        stage("Build") {
             withCredentials([pennsieveNexusCreds]) {
-                sh "$sbt +common/publish"
-                sh "$sbt +client/publish"
+                sh "$sbt clean +compile"
             }
         }
 
-        stage("Docker") {
+        stage("Test") {
             withCredentials([pennsieveNexusCreds]) {
-                sh "$sbt clean server/docker"
+                try {
+                    sh "$sbt coverageOn +test"
+                } finally {
+                    junit '**/target/test-reports/*.xml'
+                }
             }
-
-            sh "docker tag pennsieve/doi-service:latest pennsieve/doi-service:$imageTag"
-            sh "docker push pennsieve/doi-service:latest"
-            sh "docker push pennsieve/doi-service:$imageTag"
         }
 
-        stage("Deploy") {
-            build job: "service-deploy/pennsieve-non-prod/us-east-1/dev-vpc-use1/dev/doi-service",
-            parameters: [
-                string(name: 'IMAGE_TAG', value: imageTag),
-                string(name: 'TERRAFORM_ACTION', value: 'apply')
-            ]
+        // stage("Integration Test") {
+        //     withCredentials([pennsieveNexusCreds]) {
+        //         try {
+        //             sh "$sbt coverageOn integration:test"
+        //         } finally {
+        //             junit '**/target/test-reports/*.xml'
+        //         }
+        //     }
+        // }
+
+        stage("Test Coverage") {
+            withCredentials([pennsieveNexusCreds]) {
+                sh "$sbt coverageReport"
+            }
+        }
+
+        if (env.BRANCH_NAME == 'main') {
+            stage("Publish Jars") {
+                withCredentials([pennsieveNexusCreds]) {
+                    sh "$sbt +common/publish"
+                    sh "$sbt +client/publish"
+                }
+            }
+
+            stage("Docker") {
+                withCredentials([pennsieveNexusCreds]) {
+                    sh "$sbt clean server/docker"
+                }
+
+                sh "docker tag pennsieve/doi-service:latest pennsieve/doi-service:$imageTag"
+                sh "docker push pennsieve/doi-service:latest"
+                sh "docker push pennsieve/doi-service:$imageTag"
+            }
+
+            stage("Deploy") {
+                build job: "service-deploy/pennsieve-non-prod/us-east-1/dev-vpc-use1/dev/doi-service",
+                parameters: [
+                    string(name: 'IMAGE_TAG', value: imageTag),
+                    string(name: 'TERRAFORM_ACTION', value: 'apply')
+                ]
+            }
         }
     }
+    catch (e) {
+        currentBuild.result = 'FAILED'
+        throw e
+    }
+    finally {
+        notifyBuild(currentBuild.result)
+    }
+}
+
+// Slack build status notifications
+def notifyBuild(String buildStatus) {
+  // Build status of null means successful
+  buildStatus = buildStatus ?: 'SUCCESS'
+
+  def authorName = sh(returnStdout: true, script: 'git --no-pager show --format="%an" --no-patch').trim()
+  def color
+  def message = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL}) by ${authorName}"
+
+  if (buildStatus == 'SUCCESS') {
+    color = '#00FF00' // Green
+  } else {
+    color = '#FF0000' // Red
+  }
+
+  slackSend(color: color, message: message)
 }

--- a/common/src/main/scala/com/pennsieve/doi/models/DataciteDoi.scala
+++ b/common/src/main/scala/com/pennsieve/doi/models/DataciteDoi.scala
@@ -9,7 +9,7 @@ import io.circe.{ Decoder, Encoder }
 import enumeratum.EnumEntry.Camelcase
 
 case class NameIdentifier(
-  nameIdentifier: String,
+  nameIdentifier: Option[String],
   schemeUri: String,
   nameIdentifierScheme: String
 )
@@ -18,7 +18,7 @@ object NameIdentifier {
   implicit val encoder: Encoder[NameIdentifier] = deriveEncoder
 
   def apply(orcid: String): NameIdentifier = {
-    NameIdentifier("https://orcid.org/" + orcid, "https://orcid.org", "ORCID")
+    NameIdentifier(Some("https://orcid.org/" + orcid), "https://orcid.org", "ORCID")
   }
 }
 

--- a/server/src/test/scala/com/pennsieve/doi/handlers/DoiHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/doi/handlers/DoiHandlerSpec.scala
@@ -1155,7 +1155,7 @@ class DoiHandlerSpec
                   None,
                   List(
                     NameIdentifier(
-                      "https://orcid.org/0000-0003-2844-0190",
+                      Some("https://orcid.org/0000-0003-2844-0190"),
                       "https://orcid.org",
                       "ORCID"
                     )
@@ -1180,6 +1180,491 @@ class DoiHandlerSpec
 
       decode[DataciteDoi](doiString) shouldBe Right(expectedDoi)
 
+    }
+  }
+
+  "DataciteDoi JSON encoder and decoder" should {
+
+    "handle DOI 10.26275/eefp-azay" in {
+      val doiString =
+        s"""
+{
+  "data": {
+    "id": "10.26275/eefp-azay",
+    "type": "dois",
+    "attributes": {
+      "doi": "10.26275/eefp-azay",
+      "prefix": "10.26275",
+      "suffix": "eefp-azay",
+      "identifiers": [],
+      "alternateIdentifiers": [],
+      "creators": [
+        {
+          "name": "Leif A Havton",
+          "nameType": "Personal",
+          "givenName": "Leif A",
+          "familyName": "Havton",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0003-1561-4331",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Natalia P Biscola",
+          "nameType": "Personal",
+          "givenName": "Natalia P",
+          "familyName": "Biscola",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0001-9345-085X",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Emanuele Plebani",
+          "nameType": "Personal",
+          "givenName": "Emanuele",
+          "familyName": "Plebani",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0002-7809-9616",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Bartek Rajwa",
+          "nameType": "Personal",
+          "givenName": "Bartek",
+          "familyName": "Rajwa",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0001-7540-8236",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Abida Shemonti",
+          "nameType": "Personal",
+          "givenName": "Abida",
+          "familyName": "Shemonti",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0001-9833-3716",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Deborah Jaffey",
+          "nameType": "Personal",
+          "givenName": "Deborah",
+          "familyName": "Jaffey",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0003-4738-4024",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Terry L Powley",
+          "nameType": "Personal",
+          "givenName": "Terry L",
+          "familyName": "Powley",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0001-6689-7058",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Janet R Keast",
+          "nameType": "Personal",
+          "givenName": "Janet R",
+          "familyName": "Keast",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0002-4341-3265",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Kun-Han Lu",
+          "nameType": "Personal",
+          "givenName": "Kun-Han",
+          "familyName": "Lu",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0002-0355-8515",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        },
+        {
+          "name": "Murat Dundar",
+          "nameType": "Personal",
+          "givenName": "Murat",
+          "familyName": "Dundar",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0001-5752-468X",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        }
+      ],
+      "titles": [
+        {
+          "title": "High-throughput segmentation of rat unmyelinated axons by deep learning"
+        }
+      ],
+      "publisher": "SPARC Consortium",
+      "container": {},
+      "publicationYear": 2023,
+      "subjects": [],
+      "contributors": [
+        {
+          "name": "Natalia Biscola",
+          "nameType": "Personal",
+          "givenName": "Natalia",
+          "familyName": "Biscola",
+          "contributorType": "ContactPerson",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifier": "https://orcid.org/0000-0001-9345-085X",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ],
+          "affiliation": []
+        }
+      ],
+      "dates": [
+        {
+          "date": "2023",
+          "dateType": "Issued"
+        }
+      ],
+      "language": null,
+      "types": {
+        "ris": "DATA",
+        "bibtex": "misc",
+        "citeproc": "dataset",
+        "schemaOrg": "Dataset",
+        "resourceTypeGeneral": "Dataset"
+      },
+      "relatedIdentifiers": [
+        {
+          "relationType": "References",
+          "relatedIdentifier": "10.26275/k0mx-jcth",
+          "relatedIdentifierType": "DOI"
+        },
+        {
+          "relationType": "IsSupplementedBy",
+          "relatedIdentifier": "10.17504/protocols.io.xpxfmpn",
+          "relatedIdentifierType": "DOI"
+        },
+        {
+          "relationType": "IsSupplementedBy",
+          "relatedIdentifier": "10.17504/protocols.io.bzwcp7aw",
+          "relatedIdentifierType": "DOI"
+        },
+        {
+          "relationType": "IsSupplementedBy",
+          "relatedIdentifier": "10.17504/protocols.io.b2ssqeee",
+          "relatedIdentifierType": "DOI"
+        }
+      ],
+      "relatedItems": [],
+      "sizes": [],
+      "formats": [],
+      "version": "2",
+      "rightsList": [
+        {
+          "rights": "Creative Commons Attribution",
+          "rightsUri": "https://spdx.org/licenses/CC-BY-4.0.json"
+        }
+      ],
+      "descriptions": [
+        {
+          "description": "Transmission electron microscopy (TEM) images and segmentation of nerve fibers",
+          "descriptionType": "Abstract"
+        }
+      ],
+      "geoLocations": [],
+      "fundingReferences": [],
+      "xml": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjYyNzUvRUVGUC1BWkFZPC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWUgbmFtZVR5cGU9IlBlcnNvbmFsIj5IYXZ0b24sIExlaWYgQTwvY3JlYXRvck5hbWU+CiAgICAgIDxnaXZlbk5hbWU+TGVpZiBBPC9naXZlbk5hbWU+CiAgICAgIDxmYW1pbHlOYW1lPkhhdnRvbjwvZmFtaWx5TmFtZT4KICAgICAgPG5hbWVJZGVudGlmaWVyIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCIgc2NoZW1lVVJJPSJodHRwczovL29yY2lkLm9yZyI+aHR0cHM6Ly9vcmNpZC5vcmcvMDAwMC0wMDAzLTE1NjEtNDMzMTwvbmFtZUlkZW50aWZpZXI+CiAgICA8L2NyZWF0b3I+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+QmlzY29sYSwgTmF0YWxpYSBQPC9jcmVhdG9yTmFtZT4KICAgICAgPGdpdmVuTmFtZT5OYXRhbGlhIFA8L2dpdmVuTmFtZT4KICAgICAgPGZhbWlseU5hbWU+QmlzY29sYTwvZmFtaWx5TmFtZT4KICAgICAgPG5hbWVJZGVudGlmaWVyIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCIgc2NoZW1lVVJJPSJodHRwczovL29yY2lkLm9yZyI+aHR0cHM6Ly9vcmNpZC5vcmcvMDAwMC0wMDAxLTkzNDUtMDg1WDwvbmFtZUlkZW50aWZpZXI+CiAgICA8L2NyZWF0b3I+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+UGxlYmFuaSwgRW1hbnVlbGU8L2NyZWF0b3JOYW1lPgogICAgICA8Z2l2ZW5OYW1lPkVtYW51ZWxlPC9naXZlbk5hbWU+CiAgICAgIDxmYW1pbHlOYW1lPlBsZWJhbmk8L2ZhbWlseU5hbWU+CiAgICAgIDxuYW1lSWRlbnRpZmllciBuYW1lSWRlbnRpZmllclNjaGVtZT0iT1JDSUQiIHNjaGVtZVVSST0iaHR0cHM6Ly9vcmNpZC5vcmciPmh0dHBzOi8vb3JjaWQub3JnLzAwMDAtMDAwMi03ODA5LTk2MTY8L25hbWVJZGVudGlmaWVyPgogICAgPC9jcmVhdG9yPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZSBuYW1lVHlwZT0iUGVyc29uYWwiPlJhandhLCBCYXJ0ZWs8L2NyZWF0b3JOYW1lPgogICAgICA8Z2l2ZW5OYW1lPkJhcnRlazwvZ2l2ZW5OYW1lPgogICAgICA8ZmFtaWx5TmFtZT5SYWp3YTwvZmFtaWx5TmFtZT4KICAgICAgPG5hbWVJZGVudGlmaWVyIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCIgc2NoZW1lVVJJPSJodHRwczovL29yY2lkLm9yZyI+aHR0cHM6Ly9vcmNpZC5vcmcvMDAwMC0wMDAxLTc1NDAtODIzNjwvbmFtZUlkZW50aWZpZXI+CiAgICA8L2NyZWF0b3I+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+U2hlbW9udGksIEFiaWRhPC9jcmVhdG9yTmFtZT4KICAgICAgPGdpdmVuTmFtZT5BYmlkYTwvZ2l2ZW5OYW1lPgogICAgICA8ZmFtaWx5TmFtZT5TaGVtb250aTwvZmFtaWx5TmFtZT4KICAgICAgPG5hbWVJZGVudGlmaWVyIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCIgc2NoZW1lVVJJPSJodHRwczovL29yY2lkLm9yZyI+aHR0cHM6Ly9vcmNpZC5vcmcvMDAwMC0wMDAxLTk4MzMtMzcxNjwvbmFtZUlkZW50aWZpZXI+CiAgICA8L2NyZWF0b3I+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+SmFmZmV5LCBEZWJvcmFoPC9jcmVhdG9yTmFtZT4KICAgICAgPGdpdmVuTmFtZT5EZWJvcmFoPC9naXZlbk5hbWU+CiAgICAgIDxmYW1pbHlOYW1lPkphZmZleTwvZmFtaWx5TmFtZT4KICAgICAgPG5hbWVJZGVudGlmaWVyIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCIgc2NoZW1lVVJJPSJodHRwczovL29yY2lkLm9yZyI+aHR0cHM6Ly9vcmNpZC5vcmcvMDAwMC0wMDAzLTQ3MzgtNDAyNDwvbmFtZUlkZW50aWZpZXI+CiAgICA8L2NyZWF0b3I+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+UG93bGV5LCBUZXJyeSBMPC9jcmVhdG9yTmFtZT4KICAgICAgPGdpdmVuTmFtZT5UZXJyeSBMPC9naXZlbk5hbWU+CiAgICAgIDxmYW1pbHlOYW1lPlBvd2xleTwvZmFtaWx5TmFtZT4KICAgICAgPG5hbWVJZGVudGlmaWVyIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCIgc2NoZW1lVVJJPSJodHRwczovL29yY2lkLm9yZyI+aHR0cHM6Ly9vcmNpZC5vcmcvMDAwMC0wMDAxLTY2ODktNzA1ODwvbmFtZUlkZW50aWZpZXI+CiAgICA8L2NyZWF0b3I+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+S2Vhc3QsIEphbmV0IFI8L2NyZWF0b3JOYW1lPgogICAgICA8Z2l2ZW5OYW1lPkphbmV0IFI8L2dpdmVuTmFtZT4KICAgICAgPGZhbWlseU5hbWU+S2Vhc3Q8L2ZhbWlseU5hbWU+CiAgICAgIDxuYW1lSWRlbnRpZmllciBuYW1lSWRlbnRpZmllclNjaGVtZT0iT1JDSUQiIHNjaGVtZVVSST0iaHR0cHM6Ly9vcmNpZC5vcmciPmh0dHBzOi8vb3JjaWQub3JnLzAwMDAtMDAwMi00MzQxLTMyNjU8L25hbWVJZGVudGlmaWVyPgogICAgPC9jcmVhdG9yPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZSBuYW1lVHlwZT0iUGVyc29uYWwiPkx1LCBLdW4tSGFuPC9jcmVhdG9yTmFtZT4KICAgICAgPGdpdmVuTmFtZT5LdW4tSGFuPC9naXZlbk5hbWU+CiAgICAgIDxmYW1pbHlOYW1lPkx1PC9mYW1pbHlOYW1lPgogICAgICA8bmFtZUlkZW50aWZpZXIgbmFtZUlkZW50aWZpZXJTY2hlbWU9Ik9SQ0lEIiBzY2hlbWVVUkk9Imh0dHBzOi8vb3JjaWQub3JnIj5odHRwczovL29yY2lkLm9yZy8wMDAwLTAwMDItMDM1NS04NTE1PC9uYW1lSWRlbnRpZmllcj4KICAgIDwvY3JlYXRvcj4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWUgbmFtZVR5cGU9IlBlcnNvbmFsIj5EdW5kYXIsIE11cmF0PC9jcmVhdG9yTmFtZT4KICAgICAgPGdpdmVuTmFtZT5NdXJhdDwvZ2l2ZW5OYW1lPgogICAgICA8ZmFtaWx5TmFtZT5EdW5kYXI8L2ZhbWlseU5hbWU+CiAgICAgIDxuYW1lSWRlbnRpZmllciBuYW1lSWRlbnRpZmllclNjaGVtZT0iT1JDSUQiIHNjaGVtZVVSST0iaHR0cHM6Ly9vcmNpZC5vcmciPmh0dHBzOi8vb3JjaWQub3JnLzAwMDAtMDAwMS01NzUyLTQ2OFg8L25hbWVJZGVudGlmaWVyPgogICAgPC9jcmVhdG9yPgogIDwvY3JlYXRvcnM+CiAgPHRpdGxlcz4KICAgIDx0aXRsZT5IaWdoLXRocm91Z2hwdXQgc2VnbWVudGF0aW9uIG9mIHJhdCB1bm15ZWxpbmF0ZWQgYXhvbnMgYnkgZGVlcCBsZWFybmluZzwvdGl0bGU+CiAgPC90aXRsZXM+CiAgPHB1Ymxpc2hlcj5TUEFSQyBDb25zb3J0aXVtPC9wdWJsaXNoZXI+CiAgPHB1YmxpY2F0aW9uWWVhcj4yMDIzPC9wdWJsaWNhdGlvblllYXI+CiAgPHJlc291cmNlVHlwZSByZXNvdXJjZVR5cGVHZW5lcmFsPSJEYXRhc2V0Ii8+CiAgPGNvbnRyaWJ1dG9ycz4KICAgIDxjb250cmlidXRvciBjb250cmlidXRvclR5cGU9IkNvbnRhY3RQZXJzb24iPgogICAgICA8Y29udHJpYnV0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+QmlzY29sYSwgTmF0YWxpYTwvY29udHJpYnV0b3JOYW1lPgogICAgICA8Z2l2ZW5OYW1lPk5hdGFsaWE8L2dpdmVuTmFtZT4KICAgICAgPGZhbWlseU5hbWU+QmlzY29sYTwvZmFtaWx5TmFtZT4KICAgICAgPG5hbWVJZGVudGlmaWVyIG5hbWVJZGVudGlmaWVyU2NoZW1lPSJPUkNJRCIgc2NoZW1lVVJJPSJodHRwczovL29yY2lkLm9yZyI+aHR0cHM6Ly9vcmNpZC5vcmcvMDAwMC0wMDAxLTkzNDUtMDg1WDwvbmFtZUlkZW50aWZpZXI+CiAgICA8L2NvbnRyaWJ1dG9yPgogIDwvY29udHJpYnV0b3JzPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMjM8L2RhdGU+CiAgPC9kYXRlcz4KICA8cmVsYXRlZElkZW50aWZpZXJzPgogICAgPHJlbGF0ZWRJZGVudGlmaWVyIHJlbGF0ZWRJZGVudGlmaWVyVHlwZT0iRE9JIiByZWxhdGlvblR5cGU9IlJlZmVyZW5jZXMiPjEwLjI2Mjc1L2swbXgtamN0aDwvcmVsYXRlZElkZW50aWZpZXI+CiAgICA8cmVsYXRlZElkZW50aWZpZXIgcmVsYXRlZElkZW50aWZpZXJUeXBlPSJET0kiIHJlbGF0aW9uVHlwZT0iSXNTdXBwbGVtZW50ZWRCeSI+MTAuMTc1MDQvcHJvdG9jb2xzLmlvLnhweGZtcG48L3JlbGF0ZWRJZGVudGlmaWVyPgogICAgPHJlbGF0ZWRJZGVudGlmaWVyIHJlbGF0ZWRJZGVudGlmaWVyVHlwZT0iRE9JIiByZWxhdGlvblR5cGU9IklzU3VwcGxlbWVudGVkQnkiPjEwLjE3NTA0L3Byb3RvY29scy5pby5iendjcDdhdzwvcmVsYXRlZElkZW50aWZpZXI+CiAgICA8cmVsYXRlZElkZW50aWZpZXIgcmVsYXRlZElkZW50aWZpZXJUeXBlPSJET0kiIHJlbGF0aW9uVHlwZT0iSXNTdXBwbGVtZW50ZWRCeSI+MTAuMTc1MDQvcHJvdG9jb2xzLmlvLmIyc3NxZWVlPC9yZWxhdGVkSWRlbnRpZmllcj4KICA8L3JlbGF0ZWRJZGVudGlmaWVycz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbj4yPC92ZXJzaW9uPgogIDxyaWdodHNMaXN0PgogICAgPHJpZ2h0cyByaWdodHNVUkk9Imh0dHBzOi8vc3BkeC5vcmcvbGljZW5zZXMvQ0MtQlktNC4wLmpzb24iPkNyZWF0aXZlIENvbW1vbnMgQXR0cmlidXRpb248L3JpZ2h0cz4KICA8L3JpZ2h0c0xpc3Q+CiAgPGRlc2NyaXB0aW9ucz4KICAgIDxkZXNjcmlwdGlvbiBkZXNjcmlwdGlvblR5cGU9IkFic3RyYWN0Ij5UcmFuc21pc3Npb24gZWxlY3Ryb24gbWljcm9zY29weSAoVEVNKSBpbWFnZXMgYW5kIHNlZ21lbnRhdGlvbiBvZiBuZXJ2ZSBmaWJlcnM8L2Rlc2NyaXB0aW9uPgogIDwvZGVzY3JpcHRpb25zPgo8L3Jlc291cmNlPgo=",
+      "url": "https://sparc.science/datasets/226/version/2",
+      "contentUrl": null,
+      "metadataVersion": 0,
+      "schemaVersion": "http://datacite.org/schema/kernel-4",
+      "source": "api",
+      "isActive": true,
+      "state": "findable",
+      "reason": null,
+      "viewCount": 0,
+      "viewsOverTime": [],
+      "downloadCount": 0,
+      "downloadsOverTime": [],
+      "referenceCount": 0,
+      "citationCount": 0,
+      "citationsOverTime": [],
+      "partCount": 0,
+      "partOfCount": 0,
+      "versionCount": 0,
+      "versionOfCount": 0,
+      "created": "2023-11-02T23:00:40.000Z",
+      "registered": "2023-11-02T23:12:04.000Z",
+      "published": "2023",
+      "updated": "2023-11-02T23:12:04.000Z"
+    },
+    "relationships": {
+      "client": {
+        "data": {
+          "id": "bf.discover",
+          "type": "clients"
+        }
+      },
+      "provider": {
+        "data": {
+          "id": "upenn",
+          "type": "providers"
+        }
+      },
+      "media": {
+        "data": {
+          "id": "10.26275/eefp-azay",
+          "type": "media"
+        }
+      },
+      "references": {
+        "data": []
+      },
+      "citations": {
+        "data": []
+      },
+      "parts": {
+        "data": []
+      },
+      "partOf": {
+        "data": []
+      },
+      "versions": {
+        "data": []
+      },
+      "versionOf": {
+        "data": []
+      }
+    }
+  }
+}
+           """
+
+      val decodedDoi = decode[DataciteDoi](doiString)
+      decodedDoi should matchPattern { case Right(_) => }
+    }
+
+    "handle DOI 10.26275/ld51-w0na" in {
+      val doiString =
+        s"""
+{
+  "data": {
+    "id": "10.26275/ld51-w0na",
+    "type": "dois",
+    "attributes": {
+      "doi": "10.26275/ld51-w0na",
+      "prefix": "10.26275",
+      "suffix": "ld51-w0na",
+      "identifiers": [],
+      "alternateIdentifiers": [],
+      "creators": [
+        {
+          "name": "E. Clancy, Colleen",
+          "nameType": "Personal",
+          "givenName": "Colleen",
+          "familyName": "E. Clancy",
+          "affiliation": [],
+          "nameIdentifiers": []
+        },
+        {
+          "name": "Jeng, Mao-Tsuen",
+          "nameType": "Personal",
+          "givenName": "Mao-Tsuen",
+          "familyName": "Jeng",
+          "affiliation": [],
+          "nameIdentifiers": []
+        },
+        {
+          "name": "Yang, Pei-Chi",
+          "nameType": "Personal",
+          "givenName": "Pei-Chi",
+          "familyName": "Yang",
+          "affiliation": [],
+          "nameIdentifiers": []
+        },
+        {
+          "name": "J. Lewis, Timothy",
+          "nameType": "Personal",
+          "givenName": "Timothy",
+          "familyName": "J. Lewis",
+          "affiliation": [],
+          "nameIdentifiers": []
+        }
+      ],
+      "titles": [
+        {
+          "title": "Multi-scale human cardiac electrophysiology models"
+        }
+      ],
+      "publisher": "Pennsieve Discover",
+      "container": {},
+      "publicationYear": 2019,
+      "subjects": [],
+      "contributors": [
+        {
+          "name": "Pascual, Ignacio",
+          "nameType": "Personal",
+          "givenName": "Ignacio",
+          "familyName": "Pascual",
+          "affiliation": [],
+          "contributorType": "ContactPerson",
+          "nameIdentifiers": [
+            {
+              "schemeUri": "https://orcid.org",
+              "nameIdentifierScheme": "ORCID"
+            }
+          ]
+        }
+      ],
+      "dates": [
+        {
+          "date": "2019",
+          "dateType": "Issued"
+        }
+      ],
+      "language": null,
+      "types": {
+        "ris": "DATA",
+        "bibtex": "misc",
+        "citeproc": "dataset",
+        "schemaOrg": "Dataset",
+        "resourceTypeGeneral": "Dataset"
+      },
+      "relatedIdentifiers": [],
+      "relatedItems": [],
+      "sizes": [],
+      "formats": [],
+      "version": "9",
+      "rightsList": [
+        {
+          "rights": "MIT",
+          "rightsUri": "https://spdx.org/licenses/MIT.json"
+        }
+      ],
+      "descriptions": [
+        {
+          "description": "A computational workflow for integration and implementation of a reusable and reproducible human cardiac multi-scale electrophysiology model. Caption: Illustration of ion channels and action potential propogation in cardiac tissue",
+          "descriptionType": "Abstract"
+        }
+      ],
+      "geoLocations": [],
+      "fundingReferences": [],
+      "xml": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMjYyNzUvTEQ1MS1XME5BPC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWUgbmFtZVR5cGU9IlBlcnNvbmFsIj5FLiBDbGFuY3ksIENvbGxlZW48L2NyZWF0b3JOYW1lPgogICAgICA8Z2l2ZW5OYW1lPkNvbGxlZW48L2dpdmVuTmFtZT4KICAgICAgPGZhbWlseU5hbWU+RS4gQ2xhbmN5PC9mYW1pbHlOYW1lPgogICAgPC9jcmVhdG9yPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZSBuYW1lVHlwZT0iUGVyc29uYWwiPkplbmcsIE1hby1Uc3VlbjwvY3JlYXRvck5hbWU+CiAgICAgIDxnaXZlbk5hbWU+TWFvLVRzdWVuPC9naXZlbk5hbWU+CiAgICAgIDxmYW1pbHlOYW1lPkplbmc8L2ZhbWlseU5hbWU+CiAgICA8L2NyZWF0b3I+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lIG5hbWVUeXBlPSJQZXJzb25hbCI+WWFuZywgUGVpLUNoaTwvY3JlYXRvck5hbWU+CiAgICAgIDxnaXZlbk5hbWU+UGVpLUNoaTwvZ2l2ZW5OYW1lPgogICAgICA8ZmFtaWx5TmFtZT5ZYW5nPC9mYW1pbHlOYW1lPgogICAgPC9jcmVhdG9yPgogICAgPGNyZWF0b3I+CiAgICAgIDxjcmVhdG9yTmFtZSBuYW1lVHlwZT0iUGVyc29uYWwiPkouIExld2lzLCBUaW1vdGh5PC9jcmVhdG9yTmFtZT4KICAgICAgPGdpdmVuTmFtZT5UaW1vdGh5PC9naXZlbk5hbWU+CiAgICAgIDxmYW1pbHlOYW1lPkouIExld2lzPC9mYW1pbHlOYW1lPgogICAgPC9jcmVhdG9yPgogIDwvY3JlYXRvcnM+CiAgPHRpdGxlcz4KICAgIDx0aXRsZT5NdWx0aS1zY2FsZSBodW1hbiBjYXJkaWFjIGVsZWN0cm9waHlzaW9sb2d5IG1vZGVsczwvdGl0bGU+CiAgPC90aXRsZXM+CiAgPHB1Ymxpc2hlcj5QZW5uc2lldmUgRGlzY292ZXI8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTk8L3B1YmxpY2F0aW9uWWVhcj4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IkRhdGFzZXQiPkRhdGFzZXQ8L3Jlc291cmNlVHlwZT4KICA8Y29udHJpYnV0b3JzPgogICAgPGNvbnRyaWJ1dG9yIGNvbnRyaWJ1dG9yVHlwZT0iQ29udGFjdFBlcnNvbiI+CiAgICAgIDxjb250cmlidXRvck5hbWUgbmFtZVR5cGU9IlBlcnNvbmFsIj5QYXNjdWFsLCBJZ25hY2lvPC9jb250cmlidXRvck5hbWU+CiAgICAgIDxnaXZlbk5hbWU+SWduYWNpbzwvZ2l2ZW5OYW1lPgogICAgICA8ZmFtaWx5TmFtZT5QYXNjdWFsPC9mYW1pbHlOYW1lPgogICAgICA8bmFtZUlkZW50aWZpZXIgbmFtZUlkZW50aWZpZXJTY2hlbWU9Ik9SQ0lEIiBzY2hlbWVVUkk9Imh0dHBzOi8vb3JjaWQub3JnIi8+CiAgICA8L2NvbnRyaWJ1dG9yPgogIDwvY29udHJpYnV0b3JzPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJJc3N1ZWQiPjIwMTk8L2RhdGU+CiAgPC9kYXRlcz4KICA8c2l6ZXMvPgogIDxmb3JtYXRzLz4KICA8dmVyc2lvbj45PC92ZXJzaW9uPgogIDxyaWdodHNMaXN0PgogICAgPHJpZ2h0cyByaWdodHNVUkk9Imh0dHBzOi8vc3BkeC5vcmcvbGljZW5zZXMvTUlULmpzb24iPk1JVDwvcmlnaHRzPgogIDwvcmlnaHRzTGlzdD4KICA8ZGVzY3JpcHRpb25zPgogICAgPGRlc2NyaXB0aW9uIGRlc2NyaXB0aW9uVHlwZT0iQWJzdHJhY3QiPkEgY29tcHV0YXRpb25hbCB3b3JrZmxvdyBmb3IgaW50ZWdyYXRpb24gYW5kIGltcGxlbWVudGF0aW9uIG9mIGEgcmV1c2FibGUgYW5kIHJlcHJvZHVjaWJsZSBodW1hbiBjYXJkaWFjIG11bHRpLXNjYWxlIGVsZWN0cm9waHlzaW9sb2d5IG1vZGVsLiBDYXB0aW9uOiBJbGx1c3RyYXRpb24gb2YgaW9uIGNoYW5uZWxzIGFuZCBhY3Rpb24gcG90ZW50aWFsIHByb3BvZ2F0aW9uIGluIGNhcmRpYWMgdGlzc3VlPC9kZXNjcmlwdGlvbj4KICA8L2Rlc2NyaXB0aW9ucz4KPC9yZXNvdXJjZT4K",
+      "url": "https://sparc.science/datasets/17/version/9",
+      "contentUrl": [],
+      "metadataVersion": 6,
+      "schemaVersion": "http://datacite.org/schema/kernel-4",
+      "source": "api",
+      "isActive": true,
+      "state": "findable",
+      "reason": null,
+      "viewCount": 0,
+      "viewsOverTime": [],
+      "downloadCount": 0,
+      "downloadsOverTime": [],
+      "referenceCount": 0,
+      "citationCount": 0,
+      "citationsOverTime": [],
+      "partCount": 0,
+      "partOfCount": 0,
+      "versionCount": 0,
+      "versionOfCount": 0,
+      "created": "2019-08-14T12:28:15.000Z",
+      "registered": "2019-08-14T12:30:27.000Z",
+      "published": "2019",
+      "updated": "2023-06-26T18:55:28.000Z"
+    },
+    "relationships": {
+      "client": {
+        "data": {
+          "id": "bf.discover",
+          "type": "clients"
+        }
+      },
+      "provider": {
+        "data": {
+          "id": "upenn",
+          "type": "providers"
+        }
+      },
+      "media": {
+        "data": {
+          "id": "10.26275/ld51-w0na",
+          "type": "media"
+        }
+      },
+      "references": {
+        "data": []
+      },
+      "citations": {
+        "data": []
+      },
+      "parts": {
+        "data": []
+      },
+      "partOf": {
+        "data": []
+      },
+      "versions": {
+        "data": []
+      },
+      "versionOf": {
+        "data": []
+      }
+    }
+  }
+}
+           """
+
+      val decodedDoi = decode[DataciteDoi](doiString)
+      decodedDoi should matchPattern { case Right(_) => }
     }
   }
 


### PR DESCRIPTION
Fix to address the SPARC reported issue: [Unpublish Dataset 17 from Pennsieve](https://app.clickup.com/t/86850n0eb).

When unpublishing versions of dataset 17, the JSON response from DataCite fails to decode into the `DataDoi` case class. This is because the `nameIdentifier` attribute is missing in a Contributor record -- I suspect because the user did not have a registered ORCID iD at the time or the ORCID iD was not provided to DataCite at the time of publication (some of the failing dataset versions were published in 2019).

The fix entails making the `nameIdentifier` field optional in the `NameIdentifier` case class:

```
case class NameIdentifier(
  nameIdentifier: Option[String],
  schemeUri: String,
  nameIdentifierScheme: String
)
```

Two tests were added to verify the fix:
- DOI `10.26275/eefp-azay` is the JSON response from DataCite for a very recently published dataset version
- DOI `10.26275/ld51-w0na` is the JSON response from DataCite for one of the versions of dataset 17 that is failing (there are 9 total that are failing for this reason)

Note: 
- also added Slack notification to the Jenkins builds